### PR TITLE
v0.17.1 (see changelog for more details).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.17.0] - 2020-01-04
+## [0.17.1] - 2020-01-08
+### Fixed
+- Missing API documentation info.
+
+## [0.17.0] - 2020-01-08
 ### Added
 - New Grunt task for release profile.
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ Collecting code coverage information (at least 50%) is just as easy, running thi
 dotnet test /p:CollectCoverage=true /p:Threshold=50 /p:ThresholdType=method /p:CoverletOutputFormat=opencover
 ```
 
-Also, you can use makefile rules of this project. Be aware that these rules only work on Linux and macOS systems:
+You can also use all makefile rules of this project. Be aware that these rules only work on Linux and macOS systems:
 
 ```
 make cbt
 ```
+
+### API Documentation
+
+The Analytics API's documentation (OpenAPI Specification, implemented with Swagger UI) can be seen by starting the ASP.NET Core API, that, by default, it's binded at the address **localhost:5000/swagger**.
 
 ## Deployment
 


### PR DESCRIPTION
Added missing information about API documentation.